### PR TITLE
fix: match correct url

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     "content_scripts": [
         {
             "matches": [
-                "https://*/*"
+                "https://*.dinbendon.net/*"
             ],
             "js": [
                 "content-script.js"


### PR DESCRIPTION
將擴充功能的 content script 作用範圍從 `*` 限制到剩下 `https://*.dinbendon.net/*` 以符合擴充功能的目的，也有利於之後如果要上架的審查程序。

已經實測一周使用OK

------

如果這個 PR 被合併且您願意加上 `hacktoberfest-accepted` 標籤（label）的話，我會非常感謝您。